### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   
   def index 
     @items = Item.includes(:user).order("id DESC")
@@ -35,6 +35,11 @@ class ItemsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,8 +38,12 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item.destroy
-    redirect_to root_path
+    if current_user.id != @item.user.id
+      redirect_to root_path
+    else
+      @item.destroy
+      redirect_to root_path
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new]
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   
   def index 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,12 +38,10 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if current_user.id != @item.user.id
-      redirect_to root_path
-    else
+    if current_user.id == @item.user.id
       @item.destroy
-      redirect_to root_path
     end
+      redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,7 +23,7 @@
       <% if current_user.id == @item.user.id %>
         <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
-        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+        <%= link_to '削除', "/items/#{@item.id}", method: :delete, class:'item-destroy' %>
       <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
 end


### PR DESCRIPTION
# What
商品削除機能の実装

# Why
furimaには商品を削除する機能が備わっており、その機能を実装するため

・ログインしているユーザーが商品を削除したら商品情報がなくなってルートパスに遷移する動画
https://gyazo.com/8c6613661bb46b65cce0c52aecdc7303

・自分が出品した商品でないと削除ボタンが表示されないことを確認する動画
https://gyazo.com/e837d4ddd6fd3f547aacc99461908da3